### PR TITLE
add support for filetype-specific cheats

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,11 @@ set the following variable in your `.vimrc`:
 In this case, I recommend that you copy `cheat40.txt` into your `.vim` folder
 and modify it to suit your needs.
 
+You can also add filetype-specific cheats, by adding `cheat40_<filetype>.txt`
+files in your `runtimepath`. If such files are present, they'll be used instead
+of the builtin documentation and for that filetype, normal `cheat40.txt` files
+will also be ignored.
+
 The syntax of a cheat sheet is very simple:
 
 - foldable sections use Vim's default markers (`{{{` and `}}}`) (see `:h


### PR DESCRIPTION
fixes #7

with this change, filetype-specific cheats become possible.

One thing that this change does not allow is to include the default cheats also in the case of filetype-specific cheats, but I thought it's not really a common use-case, and in that case, the user could copy the default cheat40.txt in their config and rename it for their filetype. Alternatively, an option could be added, but I wanted to keep things as simple as possible.